### PR TITLE
Fix bad unit in mapcss message

### DIFF
--- a/power.validator.mapcss
+++ b/power.validator.mapcss
@@ -861,7 +861,7 @@ node[power=transformer][transformer][transformer!~/^(main|auxiliary|generator|co
 	assertNoMatch: "way power=plant plant:output:electricity=\"700 mw\"";
 	assertNoMatch: "way power=plant plant:output:electricity=\"700GW\"";
 	assertNoMatch: "way power=plant plant:output:electricity=\"700.0 MW\"";
-	-osmoseDetail: tr("The output tag should be a number with the '.' as a decimal separator and units in W/KW/MW/GW.");
+	-osmoseDetail: tr("The output tag should be a number with the '.' as a decimal separator and units in W/kW/MW/GW.");
 	-osmoseResource: "https://wiki.openstreetmap.org/wiki/Key:plant:output";
 }
 
@@ -890,6 +890,6 @@ node[power=transformer][transformer][transformer!~/^(main|auxiliary|generator|co
 	assertNoMatch: "way power=generator generator:output:electricity=\"700 mw\"";
 	assertNoMatch: "way power=generator generator:output:electricity=\"700GW\"";
 	assertNoMatch: "way power=generator generator:output:electricity=\"700.0 MW\"";
-	-osmoseDetail: tr("The output tag should be a number with the '.' as a decimal separator and units in W/KW/MW/GW.");
+	-osmoseDetail: tr("The output tag should be a number with the '.' as a decimal separator and units in W/kW/MW/GW.");
 	-osmoseResource: "https://wiki.openstreetmap.org/wiki/Key:generator:output";
 }


### PR DESCRIPTION
Fix the bad unit, fixes #13 

(The rule itself already uses valid capitalisation, although it's also a case insensitive regex so that doesn't help... Perhaps it should be made case sensitive in the future so that unlikely units (e.g. 100 mW instead of 100 MW, a factor 1000000000 different, or nonexistent units like gW or KW, are also not detected. But that's off topic)